### PR TITLE
Config UX: select server only (no path) and enter a raw token

### DIFF
--- a/app/actions/client.py
+++ b/app/actions/client.py
@@ -105,7 +105,7 @@ async def verify_credentials(auth_config, session=None):
         session = httpx.AsyncClient(timeout=120)
     try:
         response = await session.get(
-            auth_config.api_url,
+            auth_config.readings_url,
             params={"per_page": 1},
             headers={"Authorization": auth_config.auth_header},
         )
@@ -125,7 +125,7 @@ async def verify_credentials(auth_config, session=None):
 async def get_readings_endpoint_response(integration, auth_config, config):
     readings_per_device = {}
     try:
-        url = auth_config.api_url
+        url = auth_config.readings_url
 
         for device in config.devices_serial_number:
             # Get current state for the device

--- a/app/actions/configurations.py
+++ b/app/actions/configurations.py
@@ -7,30 +7,32 @@ from .core import AuthActionConfiguration, PullActionConfiguration, ExecutableAc
 
 
 class ZentraCloudServer(str, Enum):
-    # ZentraCloud's regional get_readings endpoints. Each server is paired with
-    # its own account token, so the choice lives with the credentials.
-    US = "https://zentracloud.com/api/v4/get_readings/"
-    EU = "https://zentracloud.eu/api/v4/get_readings/"
-    TAHMO = "https://tahmo.zentracloud.com/api/v4/get_readings/"
+    # ZentraCloud's regional servers. Each is paired with its own account token,
+    # so the choice lives with the credentials. Stored as the server base only;
+    # the get_readings path is appended by the client (see readings_url).
+    US = "https://zentracloud.com"
+    EU = "https://zentracloud.eu"
+    TAHMO = "https://tahmo.zentracloud.com"
 
 
-# Choices rendered as an inline JSON-schema enum (value -> label). The Gundi
-# portal does not dereference $ref, so a Pydantic Enum-typed field (which emits
-# allOf/$ref) won't render as a choice control. A plain str field with an inline
-# `enum` renders as a select, while the validator below keeps the value
-# constrained to the known servers server-side.
+# Rendered as an inline JSON-schema enum (value -> label). The Gundi portal does
+# not dereference $ref, so a plain str field with an inline `enum` is used (a
+# Pydantic Enum-typed field would emit allOf/$ref and not render as a select).
 SERVER_LABELS = {
     ZentraCloudServer.US.value: "ZentraCloud US",
     ZentraCloudServer.EU.value: "ZentraCloud EU",
     ZentraCloudServer.TAHMO.value: "TAHMO",
 }
 
+# Path appended to the selected server to reach the readings endpoint.
+READINGS_PATH = "api/v4/get_readings/"
+
 
 class AuthenticateConfig(AuthActionConfiguration, ExecutableActionMixin):
     token: SecretStr = FieldWithUIOptions(
         ...,
         title="Token",
-        description="ZentraCloud API token.",
+        description="Your ZentraCloud API token (just the token value, without a 'Token ' prefix).",
         ui_options=UIOptions(
             widget="password",
         ),
@@ -52,18 +54,29 @@ class AuthenticateConfig(AuthActionConfiguration, ExecutableActionMixin):
 
     @validator("api_url")
     def api_url_must_be_known_server(cls, value):
-        if value not in SERVER_LABELS:
+        server = value.rstrip("/")
+        # Tolerate a previously-stored full readings URL by reducing it to the
+        # server base, so existing integrations keep working until re-selected.
+        suffix = "/" + READINGS_PATH.strip("/")
+        if server.endswith(suffix):
+            server = server[: -len(suffix)]
+        if server not in SERVER_LABELS:
             raise ValueError(
                 f"api_url must be one of the known ZentraCloud servers: "
                 f"{', '.join(SERVER_LABELS)}"
             )
-        return value
+        return server
+
+    @property
+    def readings_url(self) -> str:
+        # The user selects only the server; append the get_readings path here.
+        return f"{self.api_url.rstrip('/')}/{READINGS_PATH}"
 
     @property
     def auth_header(self) -> str:
-        # ZentraCloud expects "Authorization: Token <token>". The token is
-        # sometimes entered in the portal already including the "Token " prefix,
-        # so normalize to exactly one prefix to avoid a "Token Token ..." 401.
+        # ZentraCloud expects "Authorization: Token <token>". Users enter just
+        # the token value; we add the prefix here. A stray "Token " prefix is
+        # tolerated to avoid a "Token Token ..." 401.
         token = self.token.get_secret_value().strip()
         if token.lower().startswith("token "):
             token = token.split(" ", 1)[1].strip()

--- a/app/actions/tests/test_client.py
+++ b/app/actions/tests/test_client.py
@@ -47,7 +47,7 @@ def test_response_keeps_unknown_sensor_types():
     assert resp.readings["Brand New Sensor"][0].readings[0].value == 7.0
 
 
-def make_config(token="Token abc123", api_url="https://zentracloud.com/api/v4/get_readings/"):
+def make_config(token="abc123", api_url="https://zentracloud.com"):
     return AuthenticateConfig.parse_obj({"token": token, "api_url": api_url})
 
 
@@ -89,7 +89,7 @@ async def test_verify_credentials_sends_normalized_header_to_chosen_server():
 
     session = httpx.AsyncClient(transport=httpx.MockTransport(handler))
     await verify_credentials(
-        make_config(token="Token abc123", api_url="https://tahmo.zentracloud.com/api/v4/get_readings/"),
+        make_config(token="abc123", api_url="https://tahmo.zentracloud.com"),
         session=session,
     )
     assert captured["auth"] == "Token abc123"

--- a/app/actions/tests/test_configurations.py
+++ b/app/actions/tests/test_configurations.py
@@ -12,69 +12,71 @@ def test_auth_config_is_executable():
     assert issubclass(AuthenticateConfig, ExecutableActionMixin)
 
 
-def test_authenticate_config_defaults_to_us_server():
-    config = AuthenticateConfig.parse_obj({"token": "Token abc123"})
-
+def test_api_url_is_the_server_only():
+    # The user selects only the server; the path is not part of the config.
+    config = AuthenticateConfig.parse_obj({"token": "abc123"})
     assert config.api_url == ZentraCloudServer.US
-    assert config.api_url == "https://zentracloud.com/api/v4/get_readings/"
+    assert config.api_url == "https://zentracloud.com"
 
 
-def test_authenticate_config_accepts_tahmo_server():
+def test_readings_url_appends_path():
+    config = AuthenticateConfig.parse_obj({"token": "abc123", "api_url": "https://tahmo.zentracloud.com"})
+    assert config.readings_url == "https://tahmo.zentracloud.com/api/v4/get_readings/"
+
+
+def test_api_url_accepts_each_known_server():
+    for server in ZentraCloudServer:
+        config = AuthenticateConfig.parse_obj({"token": "abc123", "api_url": server.value})
+        assert config.api_url == server
+
+
+def test_api_url_tolerates_previously_stored_full_url():
+    # Existing integrations stored the full readings URL; normalize it to the
+    # server base so the running pull doesn't break before re-selection.
     config = AuthenticateConfig.parse_obj({
-        "token": "Token abc123",
+        "token": "abc123",
         "api_url": "https://tahmo.zentracloud.com/api/v4/get_readings/",
     })
-
     assert config.api_url == ZentraCloudServer.TAHMO
+    assert config.readings_url == "https://tahmo.zentracloud.com/api/v4/get_readings/"
 
 
-def test_authenticate_config_rejects_unknown_server():
-    # Select list: only the known ZentraCloud servers (US/EU/TAHMO) are valid;
-    # an arbitrary URL must be rejected rather than silently used.
+def test_api_url_rejects_unknown_server():
     with pytest.raises(pydantic.ValidationError):
-        AuthenticateConfig.parse_obj({
-            "token": "Token abc123",
-            "api_url": "https://example.com/api/v4/get_readings/",
-        })
+        AuthenticateConfig.parse_obj({"token": "abc123", "api_url": "https://example.com"})
 
 
-def test_authenticate_config_rejects_empty_api_url():
+def test_api_url_rejects_empty():
     with pytest.raises(pydantic.ValidationError):
-        AuthenticateConfig.parse_obj({
-            "token": "Token abc123",
-            "api_url": "",
-        })
+        AuthenticateConfig.parse_obj({"token": "abc123", "api_url": ""})
 
 
-def test_authenticate_config_renders_as_inline_enum_select():
-    # The portal does not dereference $ref, so the choices must be an inline
-    # JSON-schema enum (not allOf/$ref from a Pydantic Enum-typed field).
+def test_api_url_renders_as_inline_enum_select():
     prop = AuthenticateConfig.schema()["properties"]["api_url"]
     assert prop.get("enum") == [s.value for s in ZentraCloudServer]
     assert "allOf" not in prop and "$ref" not in prop
     assert AuthenticateConfig.ui_schema()["api_url"]["ui:widget"] == "select"
 
 
-def test_auth_header_normalizes_token_without_prefix():
-    config = AuthenticateConfig.parse_obj({"token": "abc123"})
+def test_server_enum_holds_base_urls_without_path():
+    assert {s.value for s in ZentraCloudServer} == {
+        "https://zentracloud.com",
+        "https://zentracloud.eu",
+        "https://tahmo.zentracloud.com",
+    }
+
+
+def test_auth_header_adds_prefix_to_raw_token():
+    config = AuthenticateConfig.parse_obj({"token": "abc123", "api_url": "https://zentracloud.com"})
     assert config.auth_header == "Token abc123"
 
 
 def test_auth_header_does_not_double_token_prefix():
-    # Portal credentials are sometimes stored already including "Token ".
-    # The header must contain exactly one prefix, not "Token Token abc123".
-    config = AuthenticateConfig.parse_obj({"token": "Token abc123"})
+    # Defensive: tolerate a token pasted with the prefix still attached.
+    config = AuthenticateConfig.parse_obj({"token": "Token abc123", "api_url": "https://zentracloud.com"})
     assert config.auth_header == "Token abc123"
 
 
 def test_auth_header_strips_surrounding_whitespace():
-    config = AuthenticateConfig.parse_obj({"token": "  Token abc123  "})
+    config = AuthenticateConfig.parse_obj({"token": "  abc123  ", "api_url": "https://zentracloud.com"})
     assert config.auth_header == "Token abc123"
-
-
-def test_server_enum_has_three_known_servers():
-    assert {s.value for s in ZentraCloudServer} == {
-        "https://zentracloud.com/api/v4/get_readings/",
-        "https://zentracloud.eu/api/v4/get_readings/",
-        "https://tahmo.zentracloud.com/api/v4/get_readings/",
-    }

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -66,8 +66,8 @@ class FakeIntegration:
 
 def make_config():
     return AuthenticateConfig.parse_obj({
-        "token": "Token abc123",
-        "api_url": "https://tahmo.zentracloud.com/api/v4/get_readings/",
+        "token": "abc123",
+        "api_url": "https://tahmo.zentracloud.com",
     })
 
 

--- a/scripts/validate_zentracloud_token.py
+++ b/scripts/validate_zentracloud_token.py
@@ -76,7 +76,7 @@ def interpret_status(status, has_device_sn):
 
 def validate(token, server, device_sn=None, per_page=1, timeout=30.0, client=None):
     config = AuthenticateConfig(token=token, api_url=SERVER_CHOICES[server])
-    url = config.api_url
+    url = config.readings_url
     headers = {"Authorization": config.auth_header}
 
     params = {


### PR DESCRIPTION
Two configuration usability changes.

## 1. API URL = server only (no path)

The select list now holds the **server base URL** (US / EU / TAHMO) instead of the full `…/api/v4/get_readings/` endpoint, so users don't need to know the path.

- New `AuthenticateConfig.readings_url` property builds the endpoint: `<server>/api/v4/get_readings/`.
- `client.get_readings_endpoint_response`, `client.verify_credentials`, and `scripts/validate_zentracloud_token.py` all use `readings_url`.
- The validator **tolerates a previously-stored full readings URL** by reducing it to the server base, so the running integration keeps working until it's re-selected in the portal (no outage on deploy).

## 2. Token = raw value

The `token` field is documented as just the token value (no `Token ` prefix). `auth_header` adds the `Token ` prefix in code (and still defensively strips a stray prefix to avoid the `Token Token …` 401 we fixed earlier), so an operator pastes only the token.

## Tests

Updated/added in `test_configurations.py`, `test_client.py`, `test_handlers.py`:
- api_url is the server base; `readings_url` appends the path; each known server accepted; unknown/empty rejected; a stored full URL normalizes to the base; inline-enum select unchanged.
- `auth_header` adds the prefix to a raw token, tolerates a stray prefix, trims whitespace.
- client/verify_credentials send to `readings_url` with the normalized header.

Full suite: **91 passed**.

## Operational note

The dropdown now stores the server base. The existing integration's stored `api_url` is the full readings URL; the backend normalizes it so pulls keep working, but the portal dropdown won't show a match until you re-select the server. Re-selecting (and confirming the token is the raw value) is recommended after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)