### PR TITLE
GUNDI-5425: handle ZentraCloud 429 rate-limits per-device (stacks on #11)

### DIFF
--- a/app/actions/client.py
+++ b/app/actions/client.py
@@ -1,4 +1,6 @@
+import asyncio
 import logging
+import re
 import pydantic
 import httpx
 
@@ -83,6 +85,80 @@ def raise_for_readings_status(response):
         message=f"ZentraCloud returned HTTP {status} for the readings request.",
         status_code=status,
     )
+
+
+# ZentraCloud rate-limit handling. Some servers (notably TAHMO) enforce a tight
+# "1 call per 60 seconds" limit and answer with HTTP 429 plus a body hint like
+# "Lock out expires in 41 seconds.". Rather than letting 429 ride the coarse
+# whole-batch retry (raise_for_readings_status treats it as transient), we wait
+# out the lockout and retry the single device, so a throttled device neither
+# aborts the batch nor re-triggers already-fetched devices.
+DEFAULT_RATE_LIMIT_WAIT_SECONDS = 60
+RATE_LIMIT_WAIT_BUFFER_SECONDS = 2  # wake up just after the lockout, not on its edge
+MAX_RATE_LIMIT_RETRIES = 3  # per device, per action run
+_LOCKOUT_RE = re.compile(r"expires in (\d+)\s*second", re.IGNORECASE)
+
+
+def _rate_limit_wait_seconds(response, default=DEFAULT_RATE_LIMIT_WAIT_SECONDS):
+    """Seconds to wait before retrying after a 429, from the server's own hints.
+
+    Prefers the standard ``Retry-After`` header (seconds form); falls back to
+    parsing ZentraCloud's ``Lock out expires in N seconds`` detail; finally
+    falls back to ``default``.
+    """
+    retry_after = (response.headers.get("Retry-After") or "").strip()
+    if retry_after.isdigit():
+        return int(retry_after)
+    try:
+        detail = response.json().get("detail", "")
+    except Exception:
+        detail = response.text or ""
+    match = _LOCKOUT_RE.search(detail or "")
+    if match:
+        return int(match.group(1))
+    return default
+
+
+async def _get_device_readings(url, params, headers, integration_id, device, session=None):
+    """GET one device's readings, waiting out ZentraCloud rate-limits (HTTP 429).
+
+    Returns the parsed JSON on success, or ``None`` if the device is still
+    rate-limited after ``MAX_RATE_LIMIT_RETRIES`` (skip it this cycle; the next
+    scheduled run picks it up). Every non-429 response is classified by
+    ``raise_for_readings_status`` (GUNDI-5425): 401/403 and other 4xx fail fast,
+    5xx stay retryable via the outer stamina loop.
+    """
+    owns_session = session is None
+    if owns_session:
+        session = httpx.AsyncClient(timeout=120)
+    try:
+        for attempt in range(1, MAX_RATE_LIMIT_RETRIES + 1):
+            response = await session.get(url, params=params, headers=headers)
+
+            if response.status_code == 429:
+                if attempt == MAX_RATE_LIMIT_RETRIES:
+                    logger.warning(
+                        f"Device '{device}' still rate-limited (HTTP 429) after "
+                        f"{attempt} attempts; skipping it this cycle.",
+                        extra={"integration_id": integration_id, "attention_needed": True},
+                    )
+                    return None
+                wait = _rate_limit_wait_seconds(response) + RATE_LIMIT_WAIT_BUFFER_SECONDS
+                logger.info(
+                    f"ZentraCloud rate-limited device '{device}' (HTTP 429); waiting "
+                    f"{wait}s before retry {attempt + 1}/{MAX_RATE_LIMIT_RETRIES}.",
+                    extra={"integration_id": integration_id},
+                )
+                await asyncio.sleep(wait)
+                continue
+
+            raise_for_readings_status(response)
+            return response.json()
+
+        return None
+    finally:
+        if owns_session:
+            await session.aclose()
 
 
 def get_auth_config(integration):
@@ -176,15 +252,17 @@ async def get_readings_endpoint_response(integration, auth_config, config):
                 "start_date": latest_device_timestamp
             }
 
-            async with httpx.AsyncClient(timeout=120) as session:
-                response = await session.get(
-                    url,
-                    params=params,
-                    headers={'Authorization': auth_config.auth_header}
-                )
-                raise_for_readings_status(response)
+            response = await _get_device_readings(
+                url=url,
+                params=params,
+                headers={'Authorization': auth_config.auth_header},
+                integration_id=str(integration.id),
+                device=device,
+            )
 
-            response = response.json()
+            if response is None:
+                # Device still rate-limited after retries; skip it this cycle.
+                continue
 
             readings = ZentraCloudResponse.parse_obj({
                 "pagination": response.get("pagination"),

--- a/app/actions/client.py
+++ b/app/actions/client.py
@@ -123,7 +123,9 @@ def _rate_limit_wait_seconds(response, default=DEFAULT_RATE_LIMIT_WAIT_SECONDS):
             detail = response.json().get("detail", "")
         except Exception:
             detail = response.text or ""
-        match = _LOCKOUT_RE.search(detail or "")
+        # detail may not be a string (e.g. a structured error object); coerce
+        # so the regex never raises and we still fall back to the default wait.
+        match = _LOCKOUT_RE.search(str(detail or ""))
         if match:
             raw = int(match.group(1))
     return max(MIN_RATE_LIMIT_WAIT_SECONDS, min(raw, MAX_RATE_LIMIT_WAIT_SECONDS))

--- a/app/actions/client.py
+++ b/app/actions/client.py
@@ -96,6 +96,12 @@ def raise_for_readings_status(response):
 DEFAULT_RATE_LIMIT_WAIT_SECONDS = 60
 RATE_LIMIT_WAIT_BUFFER_SECONDS = 2  # wake up just after the lockout, not on its edge
 MAX_RATE_LIMIT_RETRIES = 3  # per device, per action run
+# Clamp the server-reported wait. The floor stops a "0 seconds" hint from
+# burning a retry on an instant re-request; the ceiling stops a bogus or huge
+# hint (e.g. "expires in 99999 seconds") from parking the whole action until the
+# MAX_ACTION_EXECUTION_TIME ack timeout kills it mid-loop.
+MIN_RATE_LIMIT_WAIT_SECONDS = 1
+MAX_RATE_LIMIT_WAIT_SECONDS = 120
 _LOCKOUT_RE = re.compile(r"expires in (\d+)\s*second", re.IGNORECASE)
 
 
@@ -104,19 +110,23 @@ def _rate_limit_wait_seconds(response, default=DEFAULT_RATE_LIMIT_WAIT_SECONDS):
 
     Prefers the standard ``Retry-After`` header (seconds form); falls back to
     parsing ZentraCloud's ``Lock out expires in N seconds`` detail; finally
-    falls back to ``default``.
+    falls back to ``default``. The result is clamped to
+    ``[MIN_RATE_LIMIT_WAIT_SECONDS, MAX_RATE_LIMIT_WAIT_SECONDS]`` so a missing,
+    zero, or absurd hint can't waste a retry or stall the action past its timeout.
     """
+    raw = default
     retry_after = (response.headers.get("Retry-After") or "").strip()
     if retry_after.isdigit():
-        return int(retry_after)
-    try:
-        detail = response.json().get("detail", "")
-    except Exception:
-        detail = response.text or ""
-    match = _LOCKOUT_RE.search(detail or "")
-    if match:
-        return int(match.group(1))
-    return default
+        raw = int(retry_after)
+    else:
+        try:
+            detail = response.json().get("detail", "")
+        except Exception:
+            detail = response.text or ""
+        match = _LOCKOUT_RE.search(detail or "")
+        if match:
+            raw = int(match.group(1))
+    return max(MIN_RATE_LIMIT_WAIT_SECONDS, min(raw, MAX_RATE_LIMIT_WAIT_SECONDS))
 
 
 async def _get_device_readings(url, params, headers, integration_id, device, session=None):

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -8,7 +8,7 @@ import app.actions.client as client
 import app.services.gundi as gundi_tools
 
 from app.actions.configurations import PullObservationsConfig, AuthenticateConfig
-from app.services.activity_logger import activity_logger
+from app.services.activity_logger import activity_logger, log_action_activity
 from app.services.state import IntegrationStateManager
 from app.services.action_scheduler import crontab_schedule
 
@@ -129,6 +129,7 @@ async def action_pull_observations(integration, action_config: PullObservationsC
         result = {"observations_extracted": 0, "details": {}}
         response_per_device = []
         total_observations = 0
+        pull_config = client.get_pull_observations_config(integration)
         async for attempt in stamina.retry_context(
                 on=httpx.HTTPError,
                 attempts=3,
@@ -139,8 +140,31 @@ async def action_pull_observations(integration, action_config: PullObservationsC
                 readings = await client.get_readings_endpoint_response(
                     integration=integration,
                     auth_config=client.get_auth_config(integration),
-                    config=client.get_pull_observations_config(integration)
+                    config=pull_config
                 )
+
+        # Devices the client dropped this cycle because ZentraCloud kept
+        # rate-limiting them (HTTP 429). This is an expected, self-healing
+        # condition on rate-limited servers (e.g. TAHMO), so instead of an
+        # error-per-occurrence we emit at most ONE collapsed activity log per
+        # run. The next scheduled run retries them.
+        rate_limited_devices = [
+            device for device in pull_config.devices_serial_number
+            if device not in (readings or {})
+        ]
+        if rate_limited_devices:
+            await log_action_activity(
+                integration_id=str(integration.id),
+                action_id="pull_observations",
+                level="INFO",
+                title=(
+                    f"{len(rate_limited_devices)} device(s) were rate-limited by "
+                    f"ZentraCloud and skipped this cycle; they will be retried on "
+                    f"the next run."
+                ),
+                config_data=pull_config.dict(),
+                data={"rate_limited_devices": rate_limited_devices},
+            )
 
         if readings:
             logger.info(f"Readings pulled with success.")

--- a/app/actions/tests/test_client.py
+++ b/app/actions/tests/test_client.py
@@ -205,6 +205,12 @@ def test_rate_limit_wait_floors_zero_hint():
     ) == MIN_RATE_LIMIT_WAIT_SECONDS
 
 
+def test_rate_limit_wait_handles_non_string_detail():
+    # A structured (non-string) detail must not raise; fall back to default.
+    response = httpx.Response(429, json={"detail": {"code": "throttled"}})
+    assert _rate_limit_wait_seconds(response, default=42) == 42
+
+
 def test_rate_limit_wait_caps_absurd_hint():
     # A bogus/huge hint must not park the action past its execution timeout.
     from app.actions.client import MAX_RATE_LIMIT_WAIT_SECONDS

--- a/app/actions/tests/test_client.py
+++ b/app/actions/tests/test_client.py
@@ -193,6 +193,29 @@ def test_rate_limit_wait_falls_back_to_default():
     assert _rate_limit_wait_seconds(response, default=99) == 99
 
 
+def test_rate_limit_wait_floors_zero_hint():
+    # A "0 seconds" / Retry-After: 0 hint must not produce an instant re-request
+    # that wastes a retry; it is floored to MIN_RATE_LIMIT_WAIT_SECONDS.
+    from app.actions.client import MIN_RATE_LIMIT_WAIT_SECONDS
+    assert _rate_limit_wait_seconds(
+        httpx.Response(429, headers={"Retry-After": "0"})
+    ) == MIN_RATE_LIMIT_WAIT_SECONDS
+    assert _rate_limit_wait_seconds(
+        httpx.Response(429, json={"detail": "Lock out expires in 0 seconds."})
+    ) == MIN_RATE_LIMIT_WAIT_SECONDS
+
+
+def test_rate_limit_wait_caps_absurd_hint():
+    # A bogus/huge hint must not park the action past its execution timeout.
+    from app.actions.client import MAX_RATE_LIMIT_WAIT_SECONDS
+    assert _rate_limit_wait_seconds(
+        httpx.Response(429, json={"detail": "Lock out expires in 99999 seconds."})
+    ) == MAX_RATE_LIMIT_WAIT_SECONDS
+    assert _rate_limit_wait_seconds(
+        httpx.Response(429, headers={"Retry-After": "100000"})
+    ) == MAX_RATE_LIMIT_WAIT_SECONDS
+
+
 @pytest.mark.asyncio
 async def test_get_device_readings_waits_then_succeeds_on_429(mocker):
     # First call is throttled, second succeeds: the device must NOT be lost,

--- a/app/actions/tests/test_client.py
+++ b/app/actions/tests/test_client.py
@@ -10,6 +10,9 @@ from app.actions.client import (
     ZentraCloudUnauthorizedException,
     PullObservationsBadConfigException,
     ZentraCloudResponse,
+    _get_device_readings,
+    _rate_limit_wait_seconds,
+    MAX_RATE_LIMIT_RETRIES,
 )
 from app.actions.configurations import AuthenticateConfig
 
@@ -165,3 +168,119 @@ async def test_verify_credentials_sends_normalized_header_to_chosen_server():
     )
     assert captured["auth"] == "Token abc123"
     assert captured["url"].startswith("https://tahmo.zentracloud.com/api/v4/get_readings/")
+
+
+def _session_from_handler(handler):
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+
+def test_rate_limit_wait_prefers_retry_after_header():
+    response = httpx.Response(429, headers={"Retry-After": "12"}, json={"detail": "slow down"})
+    assert _rate_limit_wait_seconds(response) == 12
+
+
+def test_rate_limit_wait_parses_lockout_detail():
+    # TAHMO's body hint when no Retry-After header is present.
+    response = httpx.Response(
+        429,
+        json={"detail": "Exceeded request limit of 1 call per 60 seconds. Lock out expires in 41 seconds."},
+    )
+    assert _rate_limit_wait_seconds(response) == 41
+
+
+def test_rate_limit_wait_falls_back_to_default():
+    response = httpx.Response(429, json={"detail": "throttled"})
+    assert _rate_limit_wait_seconds(response, default=99) == 99
+
+
+@pytest.mark.asyncio
+async def test_get_device_readings_waits_then_succeeds_on_429(mocker):
+    # First call is throttled, second succeeds: the device must NOT be lost,
+    # and we must have honored a wait between the two calls.
+    sleep = mocker.patch("app.actions.client.asyncio.sleep", new_callable=mocker.AsyncMock)
+    calls = {"n": 0}
+
+    def handler(request):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return httpx.Response(429, json={"detail": "Lock out expires in 5 seconds."})
+        return httpx.Response(200, json={"pagination": {}, "data": {}})
+
+    result = await _get_device_readings(
+        url="https://tahmo.zentracloud.com/api/v4/get_readings/",
+        params={"device_sn": "z6-27505"},
+        headers={"Authorization": "Token abc"},
+        integration_id="intid",
+        device="z6-27505",
+        session=_session_from_handler(handler),
+    )
+
+    assert result == {"pagination": {}, "data": {}}
+    assert calls["n"] == 2
+    sleep.assert_awaited_once()
+    # Honors the server's lock-out hint (5s) plus the small buffer.
+    assert sleep.await_args.args[0] == 5 + 2
+
+
+@pytest.mark.asyncio
+async def test_get_device_readings_returns_none_when_persistently_429(mocker):
+    # A device that never recovers is skipped (None), not raised — so it can't
+    # abort the rest of the batch.
+    mocker.patch("app.actions.client.asyncio.sleep", new_callable=mocker.AsyncMock)
+    calls = {"n": 0}
+
+    def handler(request):
+        calls["n"] += 1
+        return httpx.Response(429, json={"detail": "Lock out expires in 60 seconds."})
+
+    result = await _get_device_readings(
+        url="https://tahmo.zentracloud.com/api/v4/get_readings/",
+        params={"device_sn": "z6-27505"},
+        headers={"Authorization": "Token abc"},
+        integration_id="intid",
+        device="z6-27505",
+        session=_session_from_handler(handler),
+    )
+
+    assert result is None
+    assert calls["n"] == MAX_RATE_LIMIT_RETRIES
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status,expected_exc", [
+    (401, ZentraCloudUnauthorizedException),
+    (403, ZentraCloudUnauthorizedException),
+    (400, PullObservationsBadConfigException),
+    (404, PullObservationsBadConfigException),
+])
+async def test_get_device_readings_fails_fast_on_non_retryable_4xx(mocker, status, expected_exc):
+    # Composition with GUNDI-5425: a non-429 4xx is classified by
+    # raise_for_readings_status and fails fast (no wait, single attempt).
+    sleep = mocker.patch("app.actions.client.asyncio.sleep", new_callable=mocker.AsyncMock)
+
+    with pytest.raises(expected_exc):
+        await _get_device_readings(
+            url="https://zentracloud.com/api/v4/get_readings/",
+            params={"device_sn": "z6-27505"},
+            headers={"Authorization": "Token abc"},
+            integration_id="intid",
+            device="z6-27505",
+            session=_session_from_handler(lambda request: httpx.Response(status, json={"detail": "nope"})),
+        )
+    sleep.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_get_device_readings_raises_retryable_on_5xx(mocker):
+    # 5xx stays an httpx error so the outer stamina loop keeps retrying it.
+    mocker.patch("app.actions.client.asyncio.sleep", new_callable=mocker.AsyncMock)
+
+    with pytest.raises(httpx.HTTPError):
+        await _get_device_readings(
+            url="https://zentracloud.com/api/v4/get_readings/",
+            params={"device_sn": "z6-27505"},
+            headers={"Authorization": "Token abc"},
+            integration_id="intid",
+            device="z6-27505",
+            session=_session_from_handler(lambda request: httpx.Response(503, json={"detail": "boom"})),
+        )

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -129,9 +129,12 @@ def _patch_pull_deps(mocker, *, devices, returned):
 async def test_pull_logs_one_collapsed_summary_for_rate_limited_devices(mocker):
     # Two of three devices were dropped by the client (persistent 429). We expect
     # exactly ONE summary activity log naming them — not one error per device.
-    summary = _patch_pull_deps(mocker, devices=["z6-1", "z6-2", "z6-3"], returned=["z6-1"])
+    devices = ["z6-1", "z6-2", "z6-3"]
+    summary = _patch_pull_deps(mocker, devices=devices, returned=["z6-1"])
 
-    await handlers.action_pull_observations(integration=FakeIntegration(), action_config=make_config())
+    await handlers.action_pull_observations(
+        integration=FakeIntegration(), action_config=_PullCfg(devices)
+    )
 
     summary.assert_awaited_once()
     kwargs = summary.await_args.kwargs
@@ -142,8 +145,11 @@ async def test_pull_logs_one_collapsed_summary_for_rate_limited_devices(mocker):
 @pytest.mark.asyncio
 async def test_pull_logs_no_summary_when_all_devices_returned(mocker):
     # No device was rate-limited → no summary activity log at all.
-    summary = _patch_pull_deps(mocker, devices=["z6-1", "z6-2"], returned=["z6-1", "z6-2"])
+    devices = ["z6-1", "z6-2"]
+    summary = _patch_pull_deps(mocker, devices=devices, returned=devices)
 
-    await handlers.action_pull_observations(integration=FakeIntegration(), action_config=make_config())
+    await handlers.action_pull_observations(
+        integration=FakeIntegration(), action_config=_PullCfg(devices)
+    )
 
     summary.assert_not_awaited()

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -100,3 +100,50 @@ async def test_action_auth_raises_on_transport_error(mocker):
 
     with pytest.raises(httpx.HTTPError):
         await handlers.action_auth(FakeIntegration(), make_config())
+
+
+class _PullCfg:
+    def __init__(self, devices):
+        self.devices_serial_number = devices
+        self.devices_per_page = 1000
+
+    def dict(self):
+        return {"devices_serial_number": self.devices_serial_number, "devices_per_page": self.devices_per_page}
+
+
+def _patch_pull_deps(mocker, *, devices, returned):
+    # Silence the activity_logger decorator's pubsub publishes.
+    mocker.patch("app.services.activity_logger.publish_event", new_callable=mocker.AsyncMock)
+    mocker.patch.object(handlers.client, "get_auth_config", return_value=object())
+    mocker.patch.object(handlers.client, "get_pull_observations_config", return_value=_PullCfg(devices))
+    mocker.patch.object(
+        handlers.client, "get_readings_endpoint_response",
+        new_callable=mocker.AsyncMock, return_value={d: object() for d in returned},
+    )
+    # Isolate the summary logic from the transform/send path.
+    mocker.patch.object(handlers, "filter_and_transform", new_callable=mocker.AsyncMock, return_value=[])
+    return mocker.patch.object(handlers, "log_action_activity", new_callable=mocker.AsyncMock)
+
+
+@pytest.mark.asyncio
+async def test_pull_logs_one_collapsed_summary_for_rate_limited_devices(mocker):
+    # Two of three devices were dropped by the client (persistent 429). We expect
+    # exactly ONE summary activity log naming them — not one error per device.
+    summary = _patch_pull_deps(mocker, devices=["z6-1", "z6-2", "z6-3"], returned=["z6-1"])
+
+    await handlers.action_pull_observations(integration=FakeIntegration(), action_config=make_config())
+
+    summary.assert_awaited_once()
+    kwargs = summary.await_args.kwargs
+    assert kwargs["level"] == "INFO"
+    assert sorted(kwargs["data"]["rate_limited_devices"]) == ["z6-2", "z6-3"]
+
+
+@pytest.mark.asyncio
+async def test_pull_logs_no_summary_when_all_devices_returned(mocker):
+    # No device was rate-limited → no summary activity log at all.
+    summary = _patch_pull_deps(mocker, devices=["z6-1", "z6-2"], returned=["z6-1", "z6-2"])
+
+    await handlers.action_pull_observations(integration=FakeIntegration(), action_config=make_config())
+
+    summary.assert_not_awaited()


### PR DESCRIPTION
## Summary

Stacks on **#11** (`fix/gundi-5425-retry-only-transient`) to refine the **429** case. #11 made permanent 4xx fail fast; this makes 429 (rate-limiting) fail *smart* instead of riding the coarse whole-batch retry.

> **Base branch is `fix/gundi-5425-retry-only-transient`, not `main`** — this is a stacked PR. GitHub will auto-retarget it to `main` once #11 merges. Please review/merge #11 first.

## In plain terms

Some data providers limit how often you can ask them for data. **TAHMO** (one of the ZentraCloud servers) allows only **one request per minute** — ask again too soon and instead of data you get a *"too many requests, come back in 41 seconds"* reply (HTTP **429**). It's not a real failure; it just means *wait a moment*. Think of a tiny bakery that serves one customer per minute.

We fetch our list of devices one at a time. On TAHMO:

- Fetch device 1 — fine, but that uses up our "one per minute."
- Immediately ask for device 2 → *"come back in 41 seconds."*
- The old behavior threw away everything and **restarted the whole list from device 1** — which re-used the minute again, so device 2 kept getting turned away and never got its turn. The run was then logged as an error in the portal.

This PR handles the *"come back later"* reply the smart way:

- Wait the **exact** time the server tells us (e.g. 41 s), not a fixed guess.
- Retry **just that one device**, instead of restarting the whole list.
- If a device is still being told to wait, **skip it this round** and pick it up on the next scheduled run — rather than failing the entire job.

### Relationship to #11 — is the "429 ownership" note an issue?

**No — it's a coordination/tidiness note, not a bug. The two PRs work together correctly.** #11 sorts errors into *"hopeless, give up now"* (e.g. a bad token) and *"worth waiting for"*, and it correctly put 429 in the worth-waiting bucket. This PR now catches the 429 case **first** and handles it itself, so #11's 429 branch (and a comment there saying the old whole-batch retry covers 429) is no longer reached on the readings path. Nothing breaks; the only risk is future confusion. The note on #11 just asks us to agree that **this PR owns the 429 case** and to clean up that now-stale comment whenever convenient.

## Problem

On rate-limited servers (notably **TAHMO**, which enforces ~1 call / 60 s), `pull_observations` fetches devices sequentially. A 429 on one device aborted the whole batch, and the outer `stamina.retry_context(on=httpx.HTTPError)` retried the *entire* batch — re-consuming the first device's rate-limit budget on every pass, so later devices were structurally starved and surfaced as `IntegrationActionFailed` activity-log errors in the portal (e.g. `429 ... device_sn=z6-27505`).

## How it composes with #11

`_get_device_readings` intercepts **429** per device; every other status defers to #11's `raise_for_readings_status`. #11's behavior is fully preserved — only the 429 row changes:

| Readings response | #11 (base) | + this PR |
|---|---|---|
| 2xx | return data | unchanged |
| 401 / 403 | fail fast (`ZentraCloudUnauthorizedException`) | unchanged |
| other 4xx | fail fast (`PullObservationsBadConfigException`) | unchanged |
| **429** | retryable → blind whole-batch 3×60s | **per-device dynamic wait + skip + 1 collapsed log** |
| 5xx | retryable (`httpx.HTTPStatusError`) | unchanged |
| conn / timeout | retryable | unchanged |

## Changes

- **`_get_device_readings`** — on 429, waits the server-reported lock-out (`Retry-After` header, else the `Lock out expires in N seconds` body hint, else 60 s, +2 s buffer) and retries **just that device**. A throttled device no longer aborts the batch or re-fetches already-fetched devices.
- **Graceful skip** — after `MAX_RATE_LIMIT_RETRIES` (3) a still-throttled device is skipped this cycle (stdout `WARNING`, *not* a raise) and picked up on the next scheduled run.
- **Collapsed activity log** — `pull_observations` emits at most **one `INFO`** activity log per run summarizing skipped devices, instead of one error per occurrence. Expected 429s no longer produce error activity logs at all (they never raise).

## Tests

- 429: dynamic-wait parsing (`Retry-After` / lock-out detail / default), wait-then-succeed, persistent-429 → skip (`None`).
- Composition with #11: non-429 4xx fail fast (no wait, single attempt); 5xx stays retryable.
- Handler: exactly one collapsed `INFO` summary when devices are skipped; none when all return.
- Full suite: **121 passed**.

## Verified locally

Live against a TAHMO integration on Gundi stage:

```
GET .../device_sn=z6-27861 → 429 Too Many Requests
ZentraCloud rate-limited device 'z6-27861' (HTTP 429); waiting 3s before retry 2/3.
GET .../device_sn=z6-27861 → 200 OK
GET .../device_sn=z6-27505 → 200 OK
→ pull HTTP 200, 2 observations sent
```

Waited the server's actual lock-out (not a blind 60 s), self-healed, both devices delivered, no error activity log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
